### PR TITLE
fix: Update Jinja2 dependency version to be less than v3.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [ { include = "cutout" } ]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-Jinja2 = ">=2.11.3"
+Jinja2 = ">=2.11.3, <3.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.3"


### PR DESCRIPTION
Jinja2 v3.1.0 and up removed contextfilter decorator.

https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0